### PR TITLE
Add jupyterlab nvdashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ The list of explicit dependencies for the project are listed in the `environment
 conda list --prefix ./env
 ```
 
+## Installing the JupyterLab extensions
+
+If you wish to make use of the JupyterLab extensions included in the `environment.yml` file, then you will need to run the `postBuild` script after activating the environment to rebuild the client-side components of the extensions. Note that this step only needs to be done once (unless you add additional JupyterLab extensions).
+
+```bash
+$ conda activate ./env
+(/path/to/project-dir/env)$ . postBuild
+```
+
 ## Using Docker
 
 In order to build Docker images for your project and run containers with GPU acceleration you will 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,11 @@
-FROM nvidia/cuda:10.1-cudnn7-runtime-ubuntu16.04
+FROM nvidia/cuda:10.1-base-ubuntu16.04
 
 LABEL maintainer="pughdr <david.pugh@kaust.edu.sa>"
 
 SHELL [ "/bin/bash", "-c" ]
 
 RUN apt-get update --fix-missing && \
-    apt-get install -y wget bzip2 curl git && \
+    apt-get install -y wget bzip2 curl git gcc && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -29,6 +29,10 @@ RUN adduser --disabled-password \
 COPY environment.yml /tmp/environment.yml
 RUN chown $UID:$GID /tmp/environment.yml
 
+COPY postBuild /usr/local/postBuild.sh
+RUN chown $UID:$GID /usr/local/postBuild.sh && \
+    chmod +x /usr/local/postBuild.sh
+
 COPY docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chown $UID:$GID /usr/local/bin/docker-entrypoint.sh && \
     chmod +x /usr/local/bin/docker-entrypoint.sh
@@ -49,6 +53,9 @@ WORKDIR $HOME/app
 RUN ~/miniconda3/bin/conda update --name base --channel defaults conda && \
     ~/miniconda3/bin/conda env create --prefix ./env --file /tmp/environment.yml && \
     ~/miniconda3/bin/conda clean --all --yes
+RUN source ~/miniconda3/bin/activate ./env && \
+    /usr/local/postBuild.sh && \
+    source ~/miniconda3/bin/deactivate
 
 # use an entrypoint script to insure conda environment is properly activated at runtime
 ENTRYPOINT [ "/usr/local/bin/docker-entrypoint.sh" ]

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
 
 dependencies:
   - cudatoolkit=10.1
-  - jupyterlab=1.1
+  - jupyterlab=1.2
   - python=3.6
   - pytorch=1.3
   - torchvision=0.4

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - cudatoolkit=10.1
   - jupyterlab=1.2
-  - python=3.6
+  - python=3.7
   - pytorch=1.3
   - torchvision=0.4
   

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,10 @@ channels:
 dependencies:
   - cudatoolkit=10.1
   - jupyterlab=1.2
+  - nodejs=12.13
+  - pip=19.3
+  - pip:
+    - jupyterlab-nvdashboard==0.1.*
   - python=3.7
   - pytorch=1.3
   - torchvision=0.4

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+jupyter labextension install --no-build jupyterlab-nvdashboard  # client-side component; server-side installed via conda/pip
+jupyter lab build


### PR DESCRIPTION
This PR add support for NVIDIA's JupyterLab extension for GPU and CPU monitoring dashboards.