### PR TITLE
Cudatoolkit virtual package

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,48 @@ Project organization is based on ideas from [_Good Enough Practices for Scientif
 9. Put project source code in the `src` directory.
 10. Name all files to reflect their content or function.
 
+## Installing NVIDIA CUDA Toolkit
+
+### Workstation
+
+You will need to have the [appropriate version](https://developer.nvidia.com/cuda-toolkit-archive) 
+of the NVIDIA CUDA Toolkit installed on your workstation. For PyTorch you should install 
+[NVIDIA CUDA Toolkit 10.1](https://developer.nvidia.com/cuda-10.1-download-archive-update2) 
+[(documentation)](https://docs.nvidia.com/cuda/archive/10.1/).
+
+After installing the appropriate version of the NVIDIA CUDA Toolkit you will need to set the 
+following environment variables.
+
+```bash
+$ export CUDA_HOME=/usr/local/cuda-10.1
+$ export PATH=$CUDA_HOME/bin:$PATH
+$ export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
+```
+
+### Ibex
+
+Ibex users do not neet to install NVIDIA CUDA Toolkit as the relevant versions have already been 
+made available on Ibex by the Ibex Systems team. Users simply need to load the appropriate version 
+using the `module` tool. 
+
+```bash
+$ module load cuda/10.1.243
+```
+
 ## Building the Conda environment
 
-After adding any necessary dependencies that should be downloaded via `conda` to the `environment.yml` file 
-and any dependencies that should be downloaded via `pip` to the `requirements.txt` file you create the 
-Conda environment in a sub-directory `./env`of your project directory by running the following commands.
+After adding any necessary dependencies that should be downloaded via `conda` to the 
+`environment.yml` file and any dependencies that should be downloaded via `pip` to the 
+`requirements.txt` file you create the Conda environment in a sub-directory `./env`of your project 
+directory by running the following commands.
 
 ```bash
 $ export ENV_PREFIX=$PWD/env
-$ export HOROVOD_CUDA_HOME=$ENV_PREFIX
+$ export HOROVOD_CUDA_HOME=$CUDA_HOME
 $ export HOROVOD_NCCL_HOME=$ENV_PREFIX
-$ export HOROVOD_GPU_ALLREDUCE=NCCL 
-$ conda env create --prefix $ENV_PREFIX --file environment.yml
+$ export HOROVOD_GPU_ALLREDUCE=NCCL
+$ export HOROVOD_GPU_BROADCAST=NCCL
+$ conda env create --prefix $ENV_PREFIX --file environment.yml --force
 ```
 
 Once the new environment has been created you can activate the environment with the following 
@@ -70,7 +100,7 @@ $ conda activate $ENV_PREFIX # optional if environment already active
 You should see output similar to the following.
 
 ```
-Horovod v0.18.2:
+Horovod v0.19.0:
 
 Available Frameworks:
     [ ] TensorFlow
@@ -84,7 +114,7 @@ Available Controllers:
 Available Tensor Operations:
     [X] NCCL
     [ ] DDL
-    [ ] MLSL
+    [ ] CCL
     [X] MPI
     [X] Gloo  
 ```
@@ -105,7 +135,7 @@ after the environment has already been created, then you can re-create the envir
 following command.
 
 ```bash
-$ conda env create --prefix #ENV_PREFIX --file environment.yml --force
+$ conda env create --prefix $ENV_PREFIX --file environment.yml --force
 ```
 
 ## Using Docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.1-base-ubuntu16.04
+FROM nvidia/cuda:10.0-devel-ubuntu16.04
 
 LABEL maintainer="pughdr <david.pugh@kaust.edu.sa>"
 
@@ -58,9 +58,10 @@ WORKDIR $PROJECT_DIR
 
 # build the conda environment
 ENV ENV_PREFIX $PROJECT_DIR/env
-ENV HOROVOD_CUDA_HOME $ENV_PREFIX
+ENV HOROVOD_CUDA_HOME $CUDA_HOME
 ENV HOROVOD_NCCL_HOME $ENV_PREFIX
 ENV HOROVOD_GPU_ALLREDUCE NCCL
+ENV HOROVOD_GPU_BROADCAST NCCL
 RUN conda update --name base --channel defaults conda && \
     conda env create --prefix $ENV_PREFIX --file /tmp/environment.yml --force && \
     conda activate $ENV_PREFIX && \

--- a/environment.yml
+++ b/environment.yml
@@ -6,18 +6,19 @@ channels:
   - defaults
 
 dependencies:
-  - cudatoolkit-dev=10.1
-  - gxx_linux-64=7.3
+  - cupti=10.1
+  - cxx-compiler=1.0
   - ipython-sql=0.3
   - jupyterlab=1.2
   - jupyterlab-git=0.9
   - nccl=2.4
-  - nodejs=12.13
+  - nvcc_linux-64=10.1
+  - nodejs=13.0
   - openmpi=4.0
   - pip=19.3
   - pip:
     - -r file:requirements.txt
   - python=3.6
-  - pytorch=1.3
-  - torchvision=0.4
+  - pytorch=1.4
+  - torchvision=0.5
   

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,9 @@ channels:
 dependencies:
   - cudatoolkit-dev=10.1
   - gxx_linux-64=7.3
+  - ipython-sql=0.3
   - jupyterlab=1.2
+  - jupyterlab-git=0.9
   - nccl=2.4
   - nodejs=12.13
   - openmpi=4.0

--- a/postBuild
+++ b/postBuild
@@ -1,2 +1,3 @@
 jupyter labextension install --no-build jupyterlab-nvdashboard  # client-side component; server-side installed via conda/pip
+jupyter serverextension enable jupyterlab_sql --py --sys-prefix
 jupyter lab build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 horovod==0.18.*
 jupyterlab-nvdashboard==0.1.*
+jupyterlab_sql==0.3.*
 
 # make sure horovod is re-compiled if environment is re-built
 --no-binary=horovod

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-horovod==0.18.*
+horovod==0.19.*
 jupyterlab-nvdashboard==0.1.*
 jupyterlab_sql==0.3.*
 


### PR DESCRIPTION
This PR moves away from using `cudatoolkit-dev` approach to getting the NVCC compiler in favour of a virtual package approach that works better on shared clusters.